### PR TITLE
fix go mod

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/defenseunicorns/generate-big-bang-zarf-package/internal/bigbang"
+	"github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package/internal/bigbang"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,4 @@
-module github.com/defenseunicorns/generate-big-bang-zarf-package
-
+module github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package
 go 1.23.1
 
 require (

--- a/internal/bigbang/bigbang.go
+++ b/internal/bigbang/bigbang.go
@@ -17,8 +17,8 @@ import (
 
 	"encoding/base64"
 
-	"github.com/defenseunicorns/generate-big-bang-zarf-package/internal/helm"
-	"github.com/defenseunicorns/generate-big-bang-zarf-package/internal/kustomize"
+	"github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package/internal/helm"
+	"github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package/internal/kustomize"
 	"github.com/google/uuid"
 
 	"github.com/Masterminds/semver/v3"

--- a/internal/helm/repo.go
+++ b/internal/helm/repo.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/defenseunicorns/generate-big-bang-zarf-package/internal/git"
+	"github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package/internal/git"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"helm.sh/helm/v3/pkg/action"

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/defenseunicorns/generate-big-bang-zarf-package/cmd"
+	"github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package/cmd"
 )
 
 const (


### PR DESCRIPTION
mod path was off from when we changed the repo name. 

Verified it now works with `go install github.com/defenseunicorns-partnerships/generate-big-bang-zarf-package@fix-mod-path`